### PR TITLE
Fix dummy data generation and trainer epoch config

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pathlib import Path
 from datetime import datetime
+import json
 
 import torch
 
@@ -61,8 +62,22 @@ def run_train(args):
         log.warning("Dummy veri veya tokenizer bulunamadı. Lütfen 'preprocess_data' ve 'train_tokenizer' görevlerini çalıştırın.")
         log.warning("Şimdilik geçici dummy veriler oluşturulacak.")
         os.makedirs(dummy_tokenizer_path, exist_ok=True)
-        with open(dummy_train_data_path, "w") as f: f.write("dummy data\n")
-        with open(dummy_eval_data_path, "w") as f: f.write("dummy data\n")
+        # JSONL formatında örnek eğitim ve değerlendirme verileri oluştur
+        sample_train_texts = [
+            {"text": "dummy training text one"},
+            {"text": "another training example"}
+        ]
+        sample_eval_texts = [
+            {"text": "dummy evaluation text"}
+        ]
+        with open(dummy_train_data_path, "w", encoding="utf-8") as f:
+            for entry in sample_train_texts:
+                json.dump(entry, f)
+                f.write("\n")
+        with open(dummy_eval_data_path, "w", encoding="utf-8") as f:
+            for entry in sample_eval_texts:
+                json.dump(entry, f)
+                f.write("\n")
         
         # Basit bir tokenizer eğit (BPE)
         temp_tokenizer_train_file = Path(base_cfg.output_dir) / "temp_tokenizer_train.txt"

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -68,13 +68,15 @@ class Trainer:
         # Toplam eğitim adımı sayısını hesapla
         # Her bir epoch için batçe sayısı * epoch sayısı
         self.num_update_steps_per_epoch = len(self.train_dataloader) // self.base_config.gradient_accumulation_steps
-        self.total_training_steps = self.num_update_steps_per_epoch * self.base_config.num_train_epochs # num_train_epochs config'e eklenecek
-        
+
         # `num_train_epochs` BaseConfig'e eklenmediyse varsayılan olarak 3 epoch alalım.
         if not hasattr(self.base_config, 'num_train_epochs'):
             self.base_config.num_train_epochs = 3
-            log.warning(f"BaseConfig'te 'num_train_epochs' bulunamadı. Varsayılan olarak {self.base_config.num_train_epochs} epoch kullanılacak.")
-            self.total_training_steps = self.num_update_steps_per_epoch * self.base_config.num_train_epochs
+            log.warning(
+                f"BaseConfig'te 'num_train_epochs' bulunamadı. Varsayılan olarak {self.base_config.num_train_epochs} epoch kullanılacak."
+            )
+
+        self.total_training_steps = self.num_update_steps_per_epoch * self.base_config.num_train_epochs
 
         self.lr_scheduler = get_scheduler(self.optimizer, self.base_config, self.total_training_steps)
         


### PR DESCRIPTION
## Summary
- Generate dummy train/eval data in JSONL format to satisfy data loader
- Safeguard trainer initialization with default `num_train_epochs`

## Testing
- `python tests/model_components_test.py`
- `python -m src.main --task train`

------
https://chatgpt.com/codex/tasks/task_e_68aae8e73b488327b8eb88678f5e713b